### PR TITLE
Hemanth - add appium capabilities to webdriver discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -170,7 +169,7 @@
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
-                <version>3.3.0.603</version>
+                <version>RELEASE</version>
             </plugin>
 
             <!--################################################-->
@@ -450,12 +449,6 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>2.3.23</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.saucelabs</groupId>
-            <artifactId>ci-sauce</artifactId>
-            <version>1.75</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/usmanhussain/framework/WebDriverDiscovery.java
+++ b/src/main/java/com/usmanhussain/framework/WebDriverDiscovery.java
@@ -1,5 +1,7 @@
 package com.usmanhussain.framework;
 
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
 import net.lightbody.bmp.BrowserMobProxy;
 import net.lightbody.bmp.BrowserMobProxyServer;
 import net.lightbody.bmp.client.ClientUtil;
@@ -22,6 +24,8 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -60,6 +64,24 @@ public class WebDriverDiscovery extends EventFiringWebDriver {
                     return new ChromeDriver(capabilities);
                 else
                     return new ChromeDriver();
+            case "appium":
+                try {
+                    DesiredCapabilities appiumCapabilities = new DesiredCapabilities();
+                    String[] appiumCaps = System.getProperty("capabilities").split(",");
+                    for (String cap : appiumCaps) {
+                        appiumCapabilities.setCapability(cap.split(":")[0], cap.split(":")[1]);
+                    }
+                    if (appiumCapabilities.asMap().containsKey("browserName")) {
+                        return new RemoteWebDriver(new URL("http://127.0.0.1:4723/wd/hub"), appiumCapabilities);
+                    } else if (appiumCapabilities.getCapability("platformName").toString().equalsIgnoreCase("android")) {
+                        return new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), appiumCapabilities);
+                    } else {
+                        return new IOSDriver(new URL("http://127.0.0.1:4723/wd/hub"), appiumCapabilities);
+                    }
+                } catch (MalformedURLException e) {
+                    e.printStackTrace();
+                    return null;
+                }
             case "saucelabs":
                 if (getPlatform().contains("iOS") || getPlatform().contains("android")) {
                     return new SauceLabsDriver(getPlatform(), getBrowserName(), getAppiumVersion(), getDeviceName(), getDeviceOrientation(), getPlatformVersion());


### PR DESCRIPTION
#sample capabalities to be passed from command line 

===================================================================
mvn clean test -DdriverType=appium -Dcapabilities=platformName:android,browserName:chrome,deviceName:<device ID>  
===================================================================
mvn clean test -DdriverType=appium -Dcapabilities=platformName:android,deviceName:<device ID>,fullReset:true,appName:app-debug.apk,appPackage:<app package>,appActivity:<app activity>,app:<full path of apk file>